### PR TITLE
fix(navigation): enable deep link navigation with global key

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,23 +24,23 @@ class _MyAppState extends State<MyApp> {
   Future<void> initAppLinks() async {
     _appLinks = AppLinks();
 
-    // 1. Handle initial link if app was launched by a deep link
     final initialUri = await _appLinks.getInitialLink();
     if (initialUri != null) _handleIncomingLink(initialUri);
 
-    // 2. Handle links while app is running
-    _sub = _appLinks.uriLinkStream.listen((Uri uri) {
-      _handleIncomingLink(uri);
-    }, onError: (err) {
-      setState(() => _status = 'Failed to receive link: $err');
-    });
+    _sub = _appLinks.uriLinkStream.listen(
+      (Uri uri) {
+        _handleIncomingLink(uri);
+      },
+      onError: (err) {
+        setState(() => _status = 'Failed to receive link: $err');
+      },
+    );
   }
 
   void _handleIncomingLink(Uri uri) {
     setState(() => _status = 'Received link: $uri');
 
     if (uri.host == 'details') {
-      // Example link: myapp://details/42
       final id = uri.pathSegments.isNotEmpty ? uri.pathSegments[0] : 'unknown';
       navigatorKey.currentState?.push(
         MaterialPageRoute(builder: (context) => DetailScreen(id: id)),
@@ -61,9 +61,7 @@ class _MyAppState extends State<MyApp> {
       title: 'Deep Link Demo',
       home: Scaffold(
         appBar: AppBar(title: Text('Home')),
-        body: Center(
-          child: Text(_status),
-        ),
+        body: Center(child: Text(_status)),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
+  final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
   late AppLinks _appLinks;
   StreamSubscription? _sub;
   String _status = 'Waiting for link...';
@@ -41,8 +42,7 @@ class _MyAppState extends State<MyApp> {
     if (uri.host == 'details') {
       // Example link: myapp://details/42
       final id = uri.pathSegments.isNotEmpty ? uri.pathSegments[0] : 'unknown';
-      Navigator.push(
-        context,
+      navigatorKey.currentState?.push(
         MaterialPageRoute(builder: (context) => DetailScreen(id: id)),
       );
     }
@@ -57,6 +57,7 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      navigatorKey: navigatorKey,
       title: 'Deep Link Demo',
       home: Scaffold(
         appBar: AppBar(title: Text('Home')),


### PR DESCRIPTION
- lib/main.dart:
  - introduce a GlobalKey<NavigatorState> to manage navigation outside of BuildContext
  - update deep link handling to use navigatorKey.currentState?.push for pushing detail screen
  - wire navigatorKey into the MaterialApp to enable global navigation control